### PR TITLE
Remove unused dependencies from Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,12 +78,6 @@ RUN mkdir /opt/workbench && \
     rm -rf /opt/workbench/libs_linux64_software_opengl /opt/workbench/plugins_linux64 && \
     strip --remove-section=.note.ABI-tag /opt/workbench/libs_linux64/libQt5Core.so.5
 
-# Convert3d 1.4.0
-FROM downloader as c3d
-RUN mkdir /opt/convert3d && \
-    curl -fsSL --retry 5 https://sourceforge.net/projects/c3d/files/c3d/Experimental/c3d-1.4.0-Linux-gcc64.tar.gz/download \
-    | tar -xz -C /opt/convert3d --strip-components 1
-
 # Micromamba
 FROM downloader as micromamba
 
@@ -173,7 +167,6 @@ RUN apt-get update -qq \
 # Install files from stages
 COPY --from=afni /opt/afni-latest /opt/afni-latest
 COPY --from=workbench /opt/workbench /opt/workbench
-COPY --from=c3d /opt/convert3d/bin/c3d_affine_tool /usr/bin/c3d_affine_tool
 
 # AFNI config
 ENV PATH="/opt/afni-latest:$PATH" \

--- a/env.yml
+++ b/env.yml
@@ -19,15 +19,12 @@ dependencies:
   - pandas=2.2
   - h5py=3.10
   # Dependencies compiled against numpy, best to stick with conda
-  - nitime=0.10
-  - scikit-image=0.22
   - scikit-learn=1.4
   # Utilities
   - graphviz=9.0
   - pandoc=3.1
-  # Workflow dependencies: ANTs
-  - ants=2.5
   # Workflow dependencies: FSL (versions pinned in 6.0.7.7)
+  # We need SUSAN and MELODIC for ICA-AROMA
   - fsl-bet2=2111.4
   - fsl-melodic=2111.3
   - fsl-miscmaths=2203.2


### PR DESCRIPTION
Closes none.

## Changes proposed in this pull request

- Drop ANTS, nitime, and skimage from the environment file.
    - We could probably drop node if we don't want the BIDS validator.
- Drop C3d from the Dockerfile.