### PR TITLE
Define padded mixing arr if skip_vols are 0

### DIFF
--- a/src/fmripost_aroma/interfaces/confounds.py
+++ b/src/fmripost_aroma/interfaces/confounds.py
@@ -81,6 +81,7 @@ def _get_ica_confounds(mixing, aroma_features, skip_vols, newpath=None):
     aroma_confounds = os.path.join(newpath, 'AROMAAggrCompAROMAConfounds.tsv')
 
     # pad mixing_arr with rows of zeros corresponding to number of non steady-state volumes
+    padded_mixing_arr = mixing_arr.copy()
     if skip_vols > 0:
         zeros = np.zeros([skip_vols, mixing_arr.shape[1]])
         padded_mixing_arr = np.vstack([zeros, mixing_arr])


### PR DESCRIPTION
Closes none. This fixes a bug where `ica_aroma_confound_extraction` will fail if `skip_vols` is 0.