### PR TITLE
Fix bids-validator installation and usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,7 +102,7 @@ RUN micromamba create -y -f /tmp/env.yml && \
 # Check if this is still necessary when updating the base image.
 ENV PATH="/opt/conda/envs/fmripost_aroma/bin:$PATH" \
     UV_USE_IO_URING=0
-RUN npm install -g svgo@^3.2.0 bids-validator@^1.14.0 && \
+RUN npm install -g svgo@^3.2.0 bids-validator@1.14.10 && \
     rm -r ~/.npm
 
 #

--- a/src/fmripost_aroma/cli/parser.py
+++ b/src/fmripost_aroma/cli/parser.py
@@ -540,6 +540,7 @@ def parse_args(args=None, namespace=None):
 
     bids_dir = config.execution.bids_dir
     output_dir = config.execution.output_dir
+    derivatives = config.execution.derivatives
     work_dir = config.execution.work_dir
     version = config.environment.version
 
@@ -571,8 +572,8 @@ def parse_args(args=None, namespace=None):
             'Please modify the output path.'
         )
 
-    # Validate inputs
-    if not opts.skip_bids_validation:
+    # Validate raw inputs if running in raw+derivatives mode
+    if derivatives and not opts.skip_bids_validation:
         from fmripost_aroma.utils.bids import validate_input_dir
 
         build_log.info(

--- a/src/fmripost_aroma/workflows/base.py
+++ b/src/fmripost_aroma/workflows/base.py
@@ -212,7 +212,7 @@ It is released under the [CC0]\
 
     config.loggers.workflow.info(
         (
-            'Collected runs:\n'
+            'Collected subject data:\n'
             f'{yaml.dump(subject_data, default_flow_style=False, indent=4)}'
         ),
     )

--- a/src/fmripost_aroma/workflows/base.py
+++ b/src/fmripost_aroma/workflows/base.py
@@ -211,10 +211,7 @@ It is released under the [CC0]\
         )
 
     config.loggers.workflow.info(
-        (
-            'Collected subject data:\n'
-            f'{yaml.dump(subject_data, default_flow_style=False, indent=4)}'
-        ),
+        f'Collected subject data:\n{yaml.dump(subject_data, default_flow_style=False, indent=4)}',
     )
 
     bids_info = pe.Node(

--- a/src/fmripost_aroma/workflows/base.py
+++ b/src/fmripost_aroma/workflows/base.py
@@ -210,6 +210,13 @@ It is released under the [CC0]\
             f"Please check your BIDS filters: {config.execution.bids_filters}."
         )
 
+    config.loggers.workflow.info(
+        (
+            'Collected runs:\n'
+            f'{yaml.dump(subject_data, default_flow_style=False, indent=4)}'
+        ),
+    )
+
     bids_info = pe.Node(
         BIDSInfo(
             bids_dir=config.execution.bids_dir,


### PR DESCRIPTION
Closes #74.

## Changes proposed in this pull request

- Install bids-validator v1.14.10 instead of newer version.
- Only validate dataset if running in raw+derivative mode.
- Print out the collected runs.