### PR TITLE
Limit file collection to specified subject

### DIFF
--- a/src/fmripost_aroma/workflows/base.py
+++ b/src/fmripost_aroma/workflows/base.py
@@ -173,6 +173,8 @@ It is released under the [CC0]\
 ### References
 
 """
+    entities = config.execution.bids_filters.copy()
+    entities['subject'] = subject_id
 
     if config.execution.derivatives:
         # Raw dataset + derivatives dataset
@@ -180,7 +182,7 @@ It is released under the [CC0]\
         subject_data = collect_derivatives(
             raw_dataset=config.execution.layout,
             derivatives_dataset=None,
-            entities=config.execution.bids_filters,
+            entities=entities,
             fieldmap_id=None,
             allow_multiple=True,
             spaces=None,
@@ -192,7 +194,7 @@ It is released under the [CC0]\
         subject_data = collect_derivatives(
             raw_dataset=None,
             derivatives_dataset=config.execution.layout,
-            entities=config.execution.bids_filters,
+            entities=entities,
             fieldmap_id=None,
             allow_multiple=True,
             spaces=None,


### PR DESCRIPTION
Closes none, but the subject workflow was collecting data for _all_ subjects in the dataset.

## Changes proposed in this pull request

- Add "subject" to the filter dictionary when looking for data.