### PR TITLE
Fix subject collection (again)

### DIFF
--- a/src/fmripost_aroma/workflows/base.py
+++ b/src/fmripost_aroma/workflows/base.py
@@ -173,7 +173,7 @@ It is released under the [CC0]\
 ### References
 
 """
-    entities = config.execution.bids_filters.copy()
+    entities = config.execution.bids_filters or {}
     entities['subject'] = subject_id
 
     if config.execution.derivatives:


### PR DESCRIPTION
Stems from #77. The fix in #77 doesn't work when `config.execution.bids_filters` is None.
