### PR TITLE
Allow run entity in transform filename

### DIFF
--- a/src/fmripost_aroma/cli/run.py
+++ b/src/fmripost_aroma/cli/run.py
@@ -223,7 +223,7 @@ def main():
 
         if sentry_sdk is not None and failed_reports:
             sentry_sdk.capture_message(
-                'Report generation failed for %d subjects' % failed_reports,
+                f'Report generation failed for {failed_reports} subjects',
                 level='error',
             )
         sys.exit(int((errno + len(failed_reports)) > 0))

--- a/src/fmripost_aroma/config.py
+++ b/src/fmripost_aroma/config.py
@@ -149,7 +149,7 @@ if not _disable_et:
     # Just get so analytics track one hit
     from contextlib import suppress
 
-    from requests import ConnectionError, ReadTimeout
+    from requests import ConnectionError, ReadTimeout  # noqa: A004
     from requests import get as _get_url
 
     with suppress((ConnectionError, ReadTimeout)):

--- a/src/fmripost_aroma/data/io_spec.json
+++ b/src/fmripost_aroma/data/io_spec.json
@@ -137,7 +137,6 @@
             },
             "anat2mni152nlin6asym": {
                 "datatype": "anat",
-                "run": null,
                 "from": ["anat", "T1w", "T2w"],
                 "to": "MNI152NLin6Asym",
                 "space": null,


### PR DESCRIPTION
Closes none, but addresses bug identified by @smeisler in https://neurostars.org/t/spaces-not-found/31162/4.

## Changes proposed in this pull request

- Remove `"run": null` from transform query.