### PR TITLE
chore: Bump minimum Python, rerun auto style fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "fmripost-aroma"
 description = 'Run ICA-AROMA on fMRIPrep derivatives'
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 license = {file = "LICENSE"}
 keywords = []
 authors = [{name = "The NiPreps Developers", email = "nipreps@gmail.com"}]

--- a/src/fmripost_aroma/cli/parser.py
+++ b/src/fmripost_aroma/cli/parser.py
@@ -216,11 +216,11 @@ def _build_parser(**kwargs):
         type=BIDSFilter,
         metavar='FILE',
         help=(
-            "A JSON file describing custom BIDS input filters using PyBIDS. "
-            "For further details, please check out "
-            "https://fmriprep.readthedocs.io/en/"
-            f"{currentv.base_version if is_release else 'latest'}/faq.html#"
-            "how-do-I-select-only-certain-files-to-be-input-to-fMRIPrep"
+            'A JSON file describing custom BIDS input filters using PyBIDS. '
+            'For further details, please check out '
+            'https://fmriprep.readthedocs.io/en/'
+            f'{currentv.base_version if is_release else "latest"}/faq.html#'
+            'how-do-I-select-only-certain-files-to-be-input-to-fMRIPrep'
         ),
     )
     g_bids.add_argument(
@@ -561,9 +561,9 @@ def parse_args(args=None, namespace=None):
     # Ensure input and output folders are not the same
     if output_dir == bids_dir:
         parser.error(
-            "The selected output folder is the same as the input BIDS folder. "
-            "Please modify the output path "
-            f"(suggestion: {bids_dir / 'derivatives' / 'fmripost_aroma-' + version.split('+')[0]}."
+            'The selected output folder is the same as the input BIDS folder. '
+            'Please modify the output path '
+            f'(suggestion: {bids_dir / "derivatives" / "fmripost_aroma-" + version.split("+")[0]}.'
         )
 
     if bids_dir in work_dir.parents:
@@ -577,8 +577,7 @@ def parse_args(args=None, namespace=None):
         from fmripost_aroma.utils.bids import validate_input_dir
 
         build_log.info(
-            'Making sure the input data is BIDS compliant '
-            '(warnings can be ignored in most cases).'
+            'Making sure the input data is BIDS compliant (warnings can be ignored in most cases).'
         )
         validate_input_dir(config.environment.exec_env, opts.bids_dir, opts.participant_label)
 
@@ -598,8 +597,8 @@ def parse_args(args=None, namespace=None):
     missing_subjects = participant_label - set(all_subjects)
     if missing_subjects:
         parser.error(
-            "One or more participant labels were not found in the BIDS directory: "
-            f"{', '.join(missing_subjects)}."
+            'One or more participant labels were not found in the BIDS directory: '
+            f'{", ".join(missing_subjects)}.'
         )
 
     config.execution.participant_label = sorted(participant_label)

--- a/src/fmripost_aroma/cli/workflow.py
+++ b/src/fmripost_aroma/cli/workflow.py
@@ -58,11 +58,11 @@ def build_workflow(config_file, retval):
     notice_path = Path(pkgrf('fmripost_aroma', 'data/NOTICE'))
     if notice_path.exists():
         banner[0] += '\n'
-        banner += [f"License NOTICE {'#' * 50}"]
+        banner += [f'License NOTICE {"#" * 50}']
         banner += [f'fMRIPost-AROMA {version}']
         banner += notice_path.read_text().splitlines(keepends=False)[1:]
         banner += ['#' * len(banner[1])]
-    build_log.log(25, f"\n{' ' * 9}".join(banner))
+    build_log.log(25, f'\n{" " * 9}'.join(banner))
 
     # warn if older results exist: check for dataset_description.json in output folder
     msg = check_pipeline_version(
@@ -110,7 +110,7 @@ def build_workflow(config_file, retval):
     if config.execution.derivatives:
         init_msg += [f'Searching for derivatives: {config.execution.derivatives}.']
 
-    build_log.log(25, f"\n{' ' * 11}* ".join(init_msg))
+    build_log.log(25, f'\n{" " * 11}* '.join(init_msg))
 
     retval['workflow'] = init_fmripost_aroma_wf()
 

--- a/src/fmripost_aroma/config.py
+++ b/src/fmripost_aroma/config.py
@@ -430,7 +430,7 @@ class execution(_Config):
     the command line) as spatial references for outputs."""
     reports_only = False
     """Only build the reports, based on the reportlets found in a cached working directory."""
-    run_uuid = f"{strftime('%Y%m%d-%H%M%S')}_{uuid4()}"
+    run_uuid = f'{strftime("%Y%m%d-%H%M%S")}_{uuid4()}'
     """Unique identifier of this particular run."""
     participant_label = None
     """List of participant identifiers that are to be preprocessed."""

--- a/src/fmripost_aroma/tests/run_local_tests.py
+++ b/src/fmripost_aroma/tests/run_local_tests.py
@@ -62,7 +62,7 @@ def run_command(command, env=None):
 
     if process.returncode != 0:
         raise RuntimeError(
-            f'Non zero return code: {process.returncode}\n' f'{command}\n\n{process.stdout.read()}'
+            f'Non zero return code: {process.returncode}\n{command}\n\n{process.stdout.read()}'
         )
 
 

--- a/src/fmripost_aroma/tests/test_utils_bids.py
+++ b/src/fmripost_aroma/tests/test_utils_bids.py
@@ -145,7 +145,7 @@ def check_expected(subject_data, expected):
         elif isinstance(value, list):
             assert subject_data[key] is not None, f'Key {key} is None.'
             assert len(subject_data[key]) == len(value)
-            for item, expected_item in zip(subject_data[key], value):
+            for item, expected_item in zip(subject_data[key], value, strict=False):
                 assert os.path.basename(item) == expected_item
         else:
             assert subject_data[key] is value

--- a/src/fmripost_aroma/tests/utils.py
+++ b/src/fmripost_aroma/tests/utils.py
@@ -115,7 +115,7 @@ def run_command(command, env=None):
 
     if process.returncode != 0:
         raise Exception(
-            f'Non zero return code: {process.returncode}\n' f'{command}\n\n{process.stdout.read()}'
+            f'Non zero return code: {process.returncode}\n{command}\n\n{process.stdout.read()}'
         )
 
 

--- a/src/fmripost_aroma/utils/bids.py
+++ b/src/fmripost_aroma/utils/bids.py
@@ -209,7 +209,11 @@ def collect_derivatives(
             derivs_cache['anat2outputspaces_xfm'] = anat2outputspaces_xfm
         else:
             missing_spaces = ', '.join(
-                [s.space for s, found in zip(spaces.references, spaces_found) if not found]
+                [
+                    s.space
+                    for s, found in zip(spaces.references, spaces_found, strict=False)
+                    if not found
+                ]
             )
             raise ValueError(
                 f'Transforms to the following requested spaces not found: {missing_spaces}.'

--- a/src/fmripost_aroma/utils/resampler.py
+++ b/src/fmripost_aroma/utils/resampler.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import asyncio
 import os
+from collections.abc import Callable
 from functools import partial
 from pathlib import Path
-from typing import Callable, TypeVar
+from typing import Annotated, TypeVar
 
 import h5py
 import nibabel as nb
@@ -21,7 +22,6 @@ from scipy.sparse import hstack as sparse_hstack
 from sdcflows.transform import grid_bspline_weights
 from sdcflows.utils.tools import ensure_positive_cosines
 from templateflow import api as tf
-from typing_extensions import Annotated
 
 R = TypeVar('R')
 

--- a/src/fmripost_aroma/utils/utils.py
+++ b/src/fmripost_aroma/utils/utils.py
@@ -440,7 +440,7 @@ def _get_wf_name(bold_fname, prefix):
 
     fname = split_filename(bold_fname)[1]
     fname_nosub = '_'.join(fname.split('_')[1:-1])
-    return f"{prefix}_{fname_nosub.replace('-', '_')}_wf"
+    return f'{prefix}_{fname_nosub.replace("-", "_")}_wf'
 
 
 def update_dict(orig_dict, new_dict):

--- a/src/fmripost_aroma/workflows/base.py
+++ b/src/fmripost_aroma/workflows/base.py
@@ -206,10 +206,10 @@ It is released under the [CC0]\
     if not subject_data['bold']:
         task_id = config.execution.task_id
         raise RuntimeError(
-            f"No BOLD images found for participant {subject_id} and "
-            f"task {task_id if task_id else '<all>'}. "
-            "All workflows require BOLD images. "
-            f"Please check your BIDS filters: {config.execution.bids_filters}."
+            f'No BOLD images found for participant {subject_id} and '
+            f'task {task_id if task_id else "<all>"}. '
+            'All workflows require BOLD images. '
+            f'Please check your BIDS filters: {config.execution.bids_filters}.'
         )
 
     config.loggers.workflow.info(


### PR DESCRIPTION
Ruff is complaining that `cli.parser` shadows `parser`, which hasn't existed since Python 3.9. This bumps the minimum Python to 3.10, which shuts ruff up about that, and then it has auto-fixes for pyupgrade complaints.