### PR TITLE
Allow "2" and "02" for resolution entity

### DIFF
--- a/src/fmripost_aroma/data/io_spec.json
+++ b/src/fmripost_aroma/data/io_spec.json
@@ -23,7 +23,7 @@
                     "mag",
                     null
                 ],
-                "res": "2",
+                "res": 2,
                 "space": "MNI152NLin6Asym",
                 "desc": "preproc",
                 "suffix": "bold",
@@ -39,7 +39,7 @@
                     "mag",
                     null
                 ],
-                "res": "2",
+                "res": 2,
                 "space": "MNI152NLin6Asym",
                 "desc": "brain",
                 "suffix": "mask",
@@ -86,7 +86,7 @@
                     "mag",
                     null
                 ],
-                "res": "2",
+                "res": 2,
                 "space": "MNI152NLin6Asym",
                 "desc": "preproc",
                 "suffix": [

--- a/src/fmripost_aroma/data/io_spec.json
+++ b/src/fmripost_aroma/data/io_spec.json
@@ -23,7 +23,7 @@
                     "mag",
                     null
                 ],
-                "res": 2,
+                "res": "2",
                 "space": "MNI152NLin6Asym",
                 "desc": "preproc",
                 "suffix": "bold",
@@ -39,7 +39,7 @@
                     "mag",
                     null
                 ],
-                "res": 2,
+                "res": "2",
                 "space": "MNI152NLin6Asym",
                 "desc": "brain",
                 "suffix": "mask",
@@ -86,7 +86,7 @@
                     "mag",
                     null
                 ],
-                "res": 2,
+                "res": "2",
                 "space": "MNI152NLin6Asym",
                 "desc": "preproc",
                 "suffix": [

--- a/src/fmripost_aroma/data/io_spec.json
+++ b/src/fmripost_aroma/data/io_spec.json
@@ -23,7 +23,7 @@
                     "mag",
                     null
                 ],
-                "res": 2,
+                "res": ["2", "02"],
                 "space": "MNI152NLin6Asym",
                 "desc": "preproc",
                 "suffix": "bold",
@@ -39,7 +39,7 @@
                     "mag",
                     null
                 ],
-                "res": 2,
+                "res": ["2", "02"],
                 "space": "MNI152NLin6Asym",
                 "desc": "brain",
                 "suffix": "mask",
@@ -86,7 +86,7 @@
                     "mag",
                     null
                 ],
-                "res": 2,
+                "res": ["2", "02"],
                 "space": "MNI152NLin6Asym",
                 "desc": "preproc",
                 "suffix": [

--- a/src/fmripost_aroma/tests/test_utils_bids.py
+++ b/src/fmripost_aroma/tests/test_utils_bids.py
@@ -198,7 +198,7 @@ def collect_derivatives_xsectional(tmpdir):
     )
     expected = {
         'bold_mni152nlin6asym': (
-            'sub-102_ses-1_task-rest_space-MNI152NLin6Asym_res-02_desc-preproc_bold.nii.gz',
+            'sub-102_ses-1_task-rest_space-MNI152NLin6Asym_res-2_desc-preproc_bold.nii.gz',
             'sub-102_ses-2_task-rest_space-MNI152NLin6Asym_res-02_desc-preproc_bold.nii.gz',
         ),
     }

--- a/src/fmripost_aroma/tests/test_utils_bids.py
+++ b/src/fmripost_aroma/tests/test_utils_bids.py
@@ -10,8 +10,21 @@ from fmripost_aroma.tests.utils import get_test_data_path
 from fmripost_aroma.utils import bids as xbids
 
 dset_xsectional = {
-    '01': [
+    '102': [
         {
+            'session': '1',
+            'func': [
+                {
+                    'task': 'rest',
+                    'space': 'MNI152NLin6Asym',
+                    'res': '02',
+                    'desc': 'preproc',
+                    'suffix': 'bold',
+                }
+            ],
+        },
+        {
+            'session': '2',
             'func': [
                 {
                     'task': 'rest',
@@ -185,7 +198,8 @@ def collect_derivatives_xsectional(tmpdir):
     )
     expected = {
         'bold_mni152nlin6asym': (
-            'sub-01_task-rest_space-MNI152NLin6Asym_res-02_desc-preproc_bold.nii.gz'
+            'sub-102_ses-1_task-rest_space-MNI152NLin6Asym_res-02_desc-preproc_bold.nii.gz',
+            'sub-102_ses-2_task-rest_space-MNI152NLin6Asym_res-02_desc-preproc_bold.nii.gz',
         ),
     }
     check_expected(subject_data, expected)

--- a/src/fmripost_aroma/tests/test_utils_bids.py
+++ b/src/fmripost_aroma/tests/test_utils_bids.py
@@ -192,14 +192,14 @@ def test_collect_derivatives_xsectional(tmpdir):
     subject_data = xbids.collect_derivatives(
         raw_dataset=None,
         derivatives_dataset=layout,
-        entities={},
+        entities={'subject': '102'},
         fieldmap_id=None,
         spec=None,
         patterns=None,
     )
     expected = {
         'bold_mni152nlin6asym': (
-            'sub-102_ses-1_task-rest_space-MNI152NLin6Asym_res-2_desc-preproc_bold.nii.gz',
+            'sub-102_ses-1_task-rest_space-MNI152NLin6Asym_res-02_desc-preproc_bold.nii.gz',
             'sub-102_ses-2_task-rest_space-MNI152NLin6Asym_res-02_desc-preproc_bold.nii.gz',
         ),
     }

--- a/src/fmripost_aroma/tests/test_utils_bids.py
+++ b/src/fmripost_aroma/tests/test_utils_bids.py
@@ -9,7 +9,7 @@ from niworkflows.utils.testing import generate_bids_skeleton
 from fmripost_aroma.tests.utils import get_test_data_path
 from fmripost_aroma.utils import bids as xbids
 
-dset_xsectional = {
+dset_xsectional_01 = {
     '102': [
         {
             'session': '1',
@@ -30,6 +30,35 @@ dset_xsectional = {
                     'task': 'rest',
                     'space': 'MNI152NLin6Asym',
                     'res': '02',
+                    'desc': 'preproc',
+                    'suffix': 'bold',
+                }
+            ],
+        },
+    ],
+}
+
+dset_xsectional_02 = {
+    '102': [
+        {
+            'session': '1',
+            'func': [
+                {
+                    'task': 'rest',
+                    'space': 'MNI152NLin6Asym',
+                    'res': '2',
+                    'desc': 'preproc',
+                    'suffix': 'bold',
+                }
+            ],
+        },
+        {
+            'session': '2',
+            'func': [
+                {
+                    'task': 'rest',
+                    'space': 'MNI152NLin6Asym',
+                    'res': '2',
                     'desc': 'preproc',
                     'suffix': 'bold',
                 }
@@ -181,11 +210,11 @@ def check_expected(subject_data, expected):
             assert subject_data[key] is value
 
 
-def test_collect_derivatives_xsectional(tmpdir):
+def test_collect_derivatives_xsectional_01(tmpdir):
     """Test collect_derivatives with a mocked up longitudinal dataset."""
     # Generate a BIDS dataset
-    bids_dir = tmpdir / 'collect_derivatives_xsectional'
-    generate_bids_skeleton(str(bids_dir), dset_xsectional)
+    bids_dir = tmpdir / 'collect_derivatives_xsectional_01'
+    generate_bids_skeleton(str(bids_dir), dset_xsectional_01)
 
     layout = BIDSLayout(bids_dir, config=['bids', 'derivatives'], validate=False)
 
@@ -201,6 +230,31 @@ def test_collect_derivatives_xsectional(tmpdir):
         'bold_mni152nlin6asym': (
             'sub-102_ses-1_task-rest_space-MNI152NLin6Asym_res-02_desc-preproc_bold.nii.gz',
             'sub-102_ses-2_task-rest_space-MNI152NLin6Asym_res-02_desc-preproc_bold.nii.gz',
+        ),
+    }
+    check_expected(subject_data, expected)
+
+
+def test_collect_derivatives_xsectional_02(tmpdir):
+    """Test collect_derivatives with a mocked up longitudinal dataset."""
+    # Generate a BIDS dataset
+    bids_dir = tmpdir / 'collect_derivatives_xsectional_02'
+    generate_bids_skeleton(str(bids_dir), dset_xsectional_02)
+
+    layout = BIDSLayout(bids_dir, config=['bids', 'derivatives'], validate=False)
+
+    subject_data = xbids.collect_derivatives(
+        raw_dataset=None,
+        derivatives_dataset=layout,
+        entities={'subject': '102'},
+        fieldmap_id=None,
+        spec=None,
+        patterns=None,
+    )
+    expected = {
+        'bold_mni152nlin6asym': (
+            'sub-102_ses-1_task-rest_space-MNI152NLin6Asym_res-2_desc-preproc_bold.nii.gz',
+            'sub-102_ses-2_task-rest_space-MNI152NLin6Asym_res-2_desc-preproc_bold.nii.gz',
         ),
     }
     check_expected(subject_data, expected)

--- a/src/fmripost_aroma/tests/test_utils_bids.py
+++ b/src/fmripost_aroma/tests/test_utils_bids.py
@@ -9,7 +9,6 @@ from niworkflows.utils.testing import generate_bids_skeleton
 from fmripost_aroma.tests.utils import get_test_data_path
 from fmripost_aroma.utils import bids as xbids
 
-
 dset_xsectional = {
     '01': [
         {

--- a/src/fmripost_aroma/tests/test_utils_bids.py
+++ b/src/fmripost_aroma/tests/test_utils_bids.py
@@ -181,7 +181,7 @@ def check_expected(subject_data, expected):
             assert subject_data[key] is value
 
 
-def collect_derivatives_xsectional(tmpdir):
+def test_collect_derivatives_xsectional(tmpdir):
     """Test collect_derivatives with a mocked up longitudinal dataset."""
     # Generate a BIDS dataset
     bids_dir = tmpdir / 'collect_derivatives_xsectional'

--- a/src/fmripost_aroma/tests/test_utils_bids.py
+++ b/src/fmripost_aroma/tests/test_utils_bids.py
@@ -242,10 +242,10 @@ def test_collect_derivatives_xsectional_01(tmpdir):
         allow_multiple=True,
     )
     expected = {
-        'bold_mni152nlin6asym': (
+        'bold_mni152nlin6asym': [
             'sub-102_ses-1_task-rest_space-MNI152NLin6Asym_res-02_desc-preproc_bold.nii.gz',
             'sub-102_ses-2_task-rest_space-MNI152NLin6Asym_res-02_desc-preproc_bold.nii.gz',
-        ),
+        ],
     }
     check_expected(subject_data, expected)
 
@@ -268,9 +268,9 @@ def test_collect_derivatives_xsectional_02(tmpdir):
         allow_multiple=True,
     )
     expected = {
-        'bold_mni152nlin6asym': (
+        'bold_mni152nlin6asym': [
             'sub-102_ses-1_task-rest_space-MNI152NLin6Asym_res-2_desc-preproc_bold.nii.gz',
             'sub-102_ses-2_task-rest_space-MNI152NLin6Asym_res-2_desc-preproc_bold.nii.gz',
-        ),
+        ],
     }
     check_expected(subject_data, expected)

--- a/src/fmripost_aroma/tests/test_utils_bids.py
+++ b/src/fmripost_aroma/tests/test_utils_bids.py
@@ -20,7 +20,14 @@ dset_xsectional_01 = {
                     'res': '02',
                     'desc': 'preproc',
                     'suffix': 'bold',
-                }
+                },
+                {
+                    'task': 'rest',
+                    'space': 'MNI152NLin6Asym',
+                    'res': '02',
+                    'desc': 'brain',
+                    'suffix': 'mask',
+                },
             ],
         },
         {
@@ -32,7 +39,14 @@ dset_xsectional_01 = {
                     'res': '02',
                     'desc': 'preproc',
                     'suffix': 'bold',
-                }
+                },
+                {
+                    'task': 'rest',
+                    'space': 'MNI152NLin6Asym',
+                    'res': '02',
+                    'desc': 'brain',
+                    'suffix': 'mask',
+                },
             ],
         },
     ],
@@ -225,6 +239,7 @@ def test_collect_derivatives_xsectional_01(tmpdir):
         fieldmap_id=None,
         spec=None,
         patterns=None,
+        allow_multiple=True,
     )
     expected = {
         'bold_mni152nlin6asym': (
@@ -250,6 +265,7 @@ def test_collect_derivatives_xsectional_02(tmpdir):
         fieldmap_id=None,
         spec=None,
         patterns=None,
+        allow_multiple=True,
     )
     expected = {
         'bold_mni152nlin6asym': (

--- a/src/fmripost_aroma/tests/test_utils_bids.py
+++ b/src/fmripost_aroma/tests/test_utils_bids.py
@@ -21,13 +21,6 @@ dset_xsectional_01 = {
                     'desc': 'preproc',
                     'suffix': 'bold',
                 },
-                {
-                    'task': 'rest',
-                    'space': 'MNI152NLin6Asym',
-                    'res': '02',
-                    'desc': 'brain',
-                    'suffix': 'mask',
-                },
             ],
         },
         {
@@ -39,13 +32,6 @@ dset_xsectional_01 = {
                     'res': '02',
                     'desc': 'preproc',
                     'suffix': 'bold',
-                },
-                {
-                    'task': 'rest',
-                    'space': 'MNI152NLin6Asym',
-                    'res': '02',
-                    'desc': 'brain',
-                    'suffix': 'mask',
                 },
             ],
         },

--- a/src/fmripost_aroma/tests/test_utils_bids.py
+++ b/src/fmripost_aroma/tests/test_utils_bids.py
@@ -190,8 +190,9 @@ def test_collect_derivatives_xsectional(tmpdir):
     layout = BIDSLayout(bids_dir, config=['bids', 'derivatives'], validate=False)
 
     subject_data = xbids.collect_derivatives(
-        raw_dataset=layout,
+        raw_dataset=None,
         derivatives_dataset=layout,
+        entities={},
         fieldmap_id=None,
         spec=None,
         patterns=None,


### PR DESCRIPTION
Closes none, but is related to https://neurostars.org/t/question-for-post-aroma/31850.

Resolution is a label-based entity, so we have to hardcode each valid value in the IO spec JSON.

## Changes proposed in this pull request

- Change the expected resolution from "2" to ["2", "02"].
- Test using `niworkflows.utils.testing.generate_bids_skeleton`.