### PR TITLE
Search for anatomical data across sessions when a given session does not have any

### DIFF
--- a/src/fmripost_aroma/tests/test_utils_bids.py
+++ b/src/fmripost_aroma/tests/test_utils_bids.py
@@ -42,6 +42,14 @@ dset_xsectional_02 = {
     '102': [
         {
             'session': '1',
+            'anat': [
+                {
+                    'space': 'MNI152NLin6Asym',
+                    'res': '02',
+                    'desc': 'preproc',
+                    'suffix': 'T1w',
+                },
+            ],
             'func': [
                 {
                     'task': 'rest',
@@ -54,6 +62,14 @@ dset_xsectional_02 = {
         },
         {
             'session': '2',
+            'anat': [
+                {
+                    'space': 'MNI152NLin6Asym',
+                    'res': '02',
+                    'desc': 'preproc',
+                    'suffix': 'T1w',
+                },
+            ],
             'func': [
                 {
                     'task': 'rest',
@@ -62,6 +78,43 @@ dset_xsectional_02 = {
                     'desc': 'preproc',
                     'suffix': 'bold',
                 }
+            ],
+        },
+    ],
+}
+
+dset_xsectional_03 = {
+    '102': [
+        {
+            'session': '1',
+            'anat': [
+                {
+                    'space': 'MNI152NLin6Asym',
+                    'res': '02',
+                    'desc': 'preproc',
+                    'suffix': 'T1w',
+                },
+            ],
+            'func': [
+                {
+                    'task': 'rest',
+                    'space': 'MNI152NLin6Asym',
+                    'res': '02',
+                    'desc': 'preproc',
+                    'suffix': 'bold',
+                },
+            ],
+        },
+        {
+            'session': '2',
+            'func': [
+                {
+                    'task': 'rest',
+                    'space': 'MNI152NLin6Asym',
+                    'res': '02',
+                    'desc': 'preproc',
+                    'suffix': 'bold',
+                },
             ],
         },
     ],
@@ -257,6 +310,57 @@ def test_collect_derivatives_xsectional_02(tmpdir):
         'bold_mni152nlin6asym': [
             'sub-102_ses-1_task-rest_space-MNI152NLin6Asym_res-2_desc-preproc_bold.nii.gz',
             'sub-102_ses-2_task-rest_space-MNI152NLin6Asym_res-2_desc-preproc_bold.nii.gz',
+        ],
+    }
+    check_expected(subject_data, expected)
+
+
+def test_collect_derivatives_xsectional_02_anat(tmpdir):
+    """Test collect_derivatives with a mocked up longitudinal dataset."""
+    # Generate a BIDS dataset
+    bids_dir = tmpdir / 'collect_derivatives_xsectional_02_anat'
+    generate_bids_skeleton(str(bids_dir), dset_xsectional_02)
+
+    layout = BIDSLayout(bids_dir, config=['bids', 'derivatives'], validate=False)
+
+    subject_data = xbids.collect_derivatives(
+        raw_dataset=None,
+        derivatives_dataset=layout,
+        entities={'subject': '102', 'session': '2'},
+        fieldmap_id=None,
+        spec=None,
+        patterns=None,
+        allow_multiple=False,
+    )
+    expected = {
+        'anat_mni152nlin6asym': [
+            'sub-102_ses-2_space-MNI152NLin6Asym_res-02_desc-preproc_T1w.nii.gz',
+        ],
+    }
+    check_expected(subject_data, expected)
+
+
+def test_collect_derivatives_xsectional_03(tmpdir):
+    """Test collect_derivatives with a mocked up longitudinal dataset."""
+    # Generate a BIDS dataset
+    bids_dir = tmpdir / 'collect_derivatives_xsectional_03'
+    generate_bids_skeleton(str(bids_dir), dset_xsectional_03)
+
+    layout = BIDSLayout(bids_dir, config=['bids', 'derivatives'], validate=False)
+
+    # Query for session 2 should return anat from session 1 if no anat is present for session 2
+    subject_data = xbids.collect_derivatives(
+        raw_dataset=None,
+        derivatives_dataset=layout,
+        entities={'subject': '102', 'session': '2'},
+        fieldmap_id=None,
+        spec=None,
+        patterns=None,
+        allow_multiple=False,
+    )
+    expected = {
+        'anat_mni152nlin6asym': [
+            'sub-102_ses-1_space-MNI152NLin6Asym_res-02_desc-preproc_T1w.nii.gz',
         ],
     }
     check_expected(subject_data, expected)

--- a/src/fmripost_aroma/tests/test_utils_bids.py
+++ b/src/fmripost_aroma/tests/test_utils_bids.py
@@ -346,16 +346,21 @@ def test_collect_derivatives_xsectional_02(tmpdir):
     check_expected(subject_data, expected)
 
     # Query for session 3 (no anat available) should raise an error
-    with pytest.raises(ValueError, match='Multiple files found for anat_mni152nlin6asym'):
-        subject_data = xbids.collect_derivatives(
-            raw_dataset=None,
-            derivatives_dataset=layout,
-            entities={'subject': '102', 'session': '3'},
-            fieldmap_id=None,
-            spec=None,
-            patterns=None,
-            allow_multiple=False,
-        )
+    subject_data = xbids.collect_derivatives(
+        raw_dataset=None,
+        derivatives_dataset=layout,
+        entities={'subject': '102', 'session': '3'},
+        fieldmap_id=None,
+        spec=None,
+        patterns=None,
+        allow_multiple=False,
+    )
+    expected = {
+        'anat_mni152nlin6asym': (
+            'sub-102_ses-2_space-MNI152NLin6Asym_res-02_desc-preproc_T1w.nii.gz'
+        ),
+    }
+    check_expected(subject_data, expected)
 
 
 def test_collect_derivatives_xsectional_03(tmpdir):

--- a/src/fmripost_aroma/tests/test_utils_bids.py
+++ b/src/fmripost_aroma/tests/test_utils_bids.py
@@ -356,9 +356,9 @@ def test_collect_derivatives_xsectional_02(tmpdir):
             entities={'subject': '102', 'session': '3'},
             fieldmap_id=None,
             spec=None,
-        patterns=None,
-        allow_multiple=False,
-    )
+            patterns=None,
+            allow_multiple=False,
+        )
 
 
 def test_collect_derivatives_xsectional_03(tmpdir):

--- a/src/fmripost_aroma/tests/test_utils_bids.py
+++ b/src/fmripost_aroma/tests/test_utils_bids.py
@@ -346,21 +346,19 @@ def test_collect_derivatives_xsectional_02(tmpdir):
     check_expected(subject_data, expected)
 
     # Query for session 3 (no anat available) should raise an error
-    subject_data = xbids.collect_derivatives(
-        raw_dataset=None,
-        derivatives_dataset=layout,
-        entities={'subject': '102', 'session': '3'},
-        fieldmap_id=None,
-        spec=None,
+    with pytest.raises(
+        ValueError,
+        match='Multiple anatomical derivatives found for anat_mni152nlin6asym',
+    ):
+        subject_data = xbids.collect_derivatives(
+            raw_dataset=None,
+            derivatives_dataset=layout,
+            entities={'subject': '102', 'session': '3'},
+            fieldmap_id=None,
+            spec=None,
         patterns=None,
         allow_multiple=False,
     )
-    expected = {
-        'anat_mni152nlin6asym': (
-            'sub-102_ses-2_space-MNI152NLin6Asym_res-02_desc-preproc_T1w.nii.gz'
-        ),
-    }
-    check_expected(subject_data, expected)
 
 
 def test_collect_derivatives_xsectional_03(tmpdir):

--- a/src/fmripost_aroma/tests/test_utils_bids.py
+++ b/src/fmripost_aroma/tests/test_utils_bids.py
@@ -339,9 +339,7 @@ def test_collect_derivatives_xsectional_02(tmpdir):
         allow_multiple=False,
     )
     expected = {
-        'anat_mni152nlin6asym': [
-            'sub-102_ses-2_space-MNI152NLin6Asym_res-02_desc-preproc_T1w.nii.gz',
-        ],
+        'anat_mni152nlin6asym': 'sub-102_ses-2_space-MNI152NLin6Asym_res-02_desc-preproc_T1w.nii.gz',
     }
     check_expected(subject_data, expected)
 
@@ -377,9 +375,7 @@ def test_collect_derivatives_xsectional_03(tmpdir):
         allow_multiple=False,
     )
     expected = {
-        'anat_mni152nlin6asym': [
-            'sub-102_ses-1_space-MNI152NLin6Asym_res-02_desc-preproc_T1w.nii.gz',
-        ],
+        'anat_mni152nlin6asym': 'sub-102_ses-1_space-MNI152NLin6Asym_res-02_desc-preproc_T1w.nii.gz',
     }
     check_expected(subject_data, expected)
 
@@ -394,8 +390,6 @@ def test_collect_derivatives_xsectional_03(tmpdir):
         allow_multiple=False,
     )
     expected = {
-        'anat_mni152nlin6asym': [
-            'sub-102_ses-1_space-MNI152NLin6Asym_res-02_desc-preproc_T1w.nii.gz',
-        ],
+        'anat_mni152nlin6asym': 'sub-102_ses-1_space-MNI152NLin6Asym_res-02_desc-preproc_T1w.nii.gz',
     }
     check_expected(subject_data, expected)

--- a/src/fmripost_aroma/tests/test_utils_bids.py
+++ b/src/fmripost_aroma/tests/test_utils_bids.py
@@ -80,6 +80,18 @@ dset_xsectional_02 = {
                 }
             ],
         },
+        {
+            'session': '3',
+            'func': [
+                {
+                    'task': 'rest',
+                    'space': 'MNI152NLin6Asym',
+                    'res': '2',
+                    'desc': 'preproc',
+                    'suffix': 'bold',
+                }
+            ],
+        },
     ],
 }
 
@@ -297,6 +309,7 @@ def test_collect_derivatives_xsectional_02(tmpdir):
 
     layout = BIDSLayout(bids_dir, config=['bids', 'derivatives'], validate=False)
 
+    # Query for all sessions should return all bold derivatives
     subject_data = xbids.collect_derivatives(
         raw_dataset=None,
         derivatives_dataset=layout,
@@ -310,19 +323,12 @@ def test_collect_derivatives_xsectional_02(tmpdir):
         'bold_mni152nlin6asym': [
             'sub-102_ses-1_task-rest_space-MNI152NLin6Asym_res-2_desc-preproc_bold.nii.gz',
             'sub-102_ses-2_task-rest_space-MNI152NLin6Asym_res-2_desc-preproc_bold.nii.gz',
+            'sub-102_ses-3_task-rest_space-MNI152NLin6Asym_res-2_desc-preproc_bold.nii.gz',
         ],
     }
     check_expected(subject_data, expected)
 
-
-def test_collect_derivatives_xsectional_02_anat(tmpdir):
-    """Test collect_derivatives with a mocked up longitudinal dataset."""
-    # Generate a BIDS dataset
-    bids_dir = tmpdir / 'collect_derivatives_xsectional_02_anat'
-    generate_bids_skeleton(str(bids_dir), dset_xsectional_02)
-
-    layout = BIDSLayout(bids_dir, config=['bids', 'derivatives'], validate=False)
-
+    # Query for session 2 should return anat from session 2
     subject_data = xbids.collect_derivatives(
         raw_dataset=None,
         derivatives_dataset=layout,
@@ -339,6 +345,18 @@ def test_collect_derivatives_xsectional_02_anat(tmpdir):
     }
     check_expected(subject_data, expected)
 
+    # Query for session 3 (no anat available) should raise an error
+    with pytest.raises(ValueError, match='Multiple files found for anat_mni152nlin6asym'):
+        subject_data = xbids.collect_derivatives(
+            raw_dataset=None,
+            derivatives_dataset=layout,
+            entities={'subject': '102', 'session': '3'},
+            fieldmap_id=None,
+            spec=None,
+            patterns=None,
+            allow_multiple=False,
+        )
+
 
 def test_collect_derivatives_xsectional_03(tmpdir):
     """Test collect_derivatives with a mocked up longitudinal dataset."""
@@ -347,6 +365,23 @@ def test_collect_derivatives_xsectional_03(tmpdir):
     generate_bids_skeleton(str(bids_dir), dset_xsectional_03)
 
     layout = BIDSLayout(bids_dir, config=['bids', 'derivatives'], validate=False)
+
+    # Query for session 1 should return anat from session 1
+    subject_data = xbids.collect_derivatives(
+        raw_dataset=None,
+        derivatives_dataset=layout,
+        entities={'subject': '102', 'session': '1'},
+        fieldmap_id=None,
+        spec=None,
+        patterns=None,
+        allow_multiple=False,
+    )
+    expected = {
+        'anat_mni152nlin6asym': [
+            'sub-102_ses-1_space-MNI152NLin6Asym_res-02_desc-preproc_T1w.nii.gz',
+        ],
+    }
+    check_expected(subject_data, expected)
 
     # Query for session 2 should return anat from session 1 if no anat is present for session 2
     subject_data = xbids.collect_derivatives(

--- a/src/fmripost_aroma/tests/test_utils_bids.py
+++ b/src/fmripost_aroma/tests/test_utils_bids.py
@@ -339,7 +339,9 @@ def test_collect_derivatives_xsectional_02(tmpdir):
         allow_multiple=False,
     )
     expected = {
-        'anat_mni152nlin6asym': 'sub-102_ses-2_space-MNI152NLin6Asym_res-02_desc-preproc_T1w.nii.gz',
+        'anat_mni152nlin6asym': (
+            'sub-102_ses-2_space-MNI152NLin6Asym_res-02_desc-preproc_T1w.nii.gz'
+        ),
     }
     check_expected(subject_data, expected)
 
@@ -375,7 +377,9 @@ def test_collect_derivatives_xsectional_03(tmpdir):
         allow_multiple=False,
     )
     expected = {
-        'anat_mni152nlin6asym': 'sub-102_ses-1_space-MNI152NLin6Asym_res-02_desc-preproc_T1w.nii.gz',
+        'anat_mni152nlin6asym': (
+            'sub-102_ses-1_space-MNI152NLin6Asym_res-02_desc-preproc_T1w.nii.gz'
+        ),
     }
     check_expected(subject_data, expected)
 
@@ -390,6 +394,8 @@ def test_collect_derivatives_xsectional_03(tmpdir):
         allow_multiple=False,
     )
     expected = {
-        'anat_mni152nlin6asym': 'sub-102_ses-1_space-MNI152NLin6Asym_res-02_desc-preproc_T1w.nii.gz',
+        'anat_mni152nlin6asym': (
+            'sub-102_ses-1_space-MNI152NLin6Asym_res-02_desc-preproc_T1w.nii.gz'
+        ),
     }
     check_expected(subject_data, expected)

--- a/src/fmripost_aroma/utils/bids.py
+++ b/src/fmripost_aroma/utils/bids.py
@@ -136,6 +136,11 @@ def collect_derivatives(
             if not item:
                 derivs_cache[k] = None
             elif not allow_multiple and len(item) > 1 and k.startswith('anat'):
+                # Raise an error if multiple derivatives are found from different sessions
+                item_sessions = [layout.get_file(f).entities['session'] for f in item]
+                if len(set(item_sessions)) > 1:
+                    raise ValueError(f'Multiple anatomical derivatives found for {k}: {item}')
+
                 # Anatomical derivatives are allowed to have multiple files (e.g., T1w and T2w)
                 # but we just grab the first one
                 derivs_cache[k] = item[0]

--- a/src/fmripost_aroma/utils/bids.py
+++ b/src/fmripost_aroma/utils/bids.py
@@ -6,7 +6,7 @@ import json
 from collections import defaultdict
 from pathlib import Path
 
-from bids.layout import BIDSLayout
+from bids.layout import BIDSLayout, Query
 from bids.utils import listify
 from niworkflows.utils.spaces import SpatialReferences
 
@@ -127,6 +127,12 @@ def collect_derivatives(
                 query = {**entities, **q}
 
             item = layout.get(return_type='filename', **query)
+            if k.startswith('anat') and not item:
+                # If the anatomical derivative is not found, try to find it
+                # across sessions
+                query = {**{'session': [Query.ANY]}, **q}
+                item = layout.get(return_type='filename', **query)
+
             if not item:
                 derivs_cache[k] = None
             elif not allow_multiple and len(item) > 1 and k.startswith('anat'):
@@ -150,6 +156,12 @@ def collect_derivatives(
                 query['to'] = fieldmap_id
 
             item = layout.get(return_type='filename', **query)
+            if k.startswith('anat') and not item:
+                # If the anatomical derivative is not found, try to find it
+                # across sessions
+                query = {**{'session': [Query.ANY]}, **q}
+                item = layout.get(return_type='filename', **query)
+
             if not item:
                 derivs_cache[k] = None
             elif not allow_multiple and len(item) > 1 and k.startswith('anat'):


### PR DESCRIPTION
Closes #85.

## Changes proposed in this pull request

- When a dataset has one session with anatomical data and other sessions with functional data, widen the search for anatomical data to all sessions. If there are anatomical data from multiple sessions, raise an error. Otherwise, just grab the first anatomical scan available (this may be T1w or T2w).