### PR TITLE
Expect flat bids_filters across package

### DIFF
--- a/src/fmripost_aroma/config.py
+++ b/src/fmripost_aroma/config.py
@@ -509,9 +509,8 @@ class execution(_Config):
                     )
 
             # unserialize pybids Query enum values
-            for acq, filters in cls.bids_filters.items():
-                for k, v in filters.items():
-                    cls.bids_filters[acq][k] = _process_value(v)
+            for entity, values in cls.bids_filters.items():
+                cls.bids_filters[entity] = _process_value(values)
 
         dataset_links = {
             'input': cls.bids_dir,

--- a/src/fmripost_aroma/data/tests/config.toml
+++ b/src/fmripost_aroma/data/tests/config.toml
@@ -48,8 +48,5 @@ stop_on_first_crash = false
 maxtasksperchild = 1
 raise_insufficient = false
 
-[execution.bids_filters.t1w]
-reconstruction = "<Query.NONE: 1>"
-
-[execution.bids_filters.t2w]
+[execution.bids_filters]
 reconstruction = "<Query.NONE: 1>"

--- a/src/fmripost_aroma/reports/core.py
+++ b/src/fmripost_aroma/reports/core.py
@@ -118,8 +118,7 @@ def generate_reports(
             # Beyond a certain number of sessions per subject,
             # we separate the functional reports per session
             if session_list is None:
-                all_filters = config.execution.bids_filters or {}
-                filters = all_filters.get('bold', {})
+                filters = config.execution.bids_filters or {}
                 session_list = config.execution.layout.get_sessions(
                     subject=subject_label, **filters
                 )

--- a/src/fmripost_aroma/tests/test_cli.py
+++ b/src/fmripost_aroma/tests/test_cli.py
@@ -137,7 +137,7 @@ def _run_and_generate(test_name, parameters, test_main=True):
 
         build_boilerplate(str(config_file), wf)
         session_list = (
-            config.execution.bids_filters.get('bold', {}).get('session')
+            config.execution.bids_filters.get('session')
             if config.execution.bids_filters
             else None
         )


### PR DESCRIPTION
Closes #109. We might need to overwrite these changes when we address #101.

## Changes proposed in this pull request

- Reduce any cases that expect `bids_filters` to be a nested dictionary (e.g., `{"bold": {"acquisition": "good"}}`) to instead expect a flat dictionary that only applies to the BOLD data (e.g., `{"acquisition": "good"}`).