### PR TITLE
Use BIDS filter in file-wise queries

### DIFF
--- a/src/fmripost_aroma/tests/test_cli.py
+++ b/src/fmripost_aroma/tests/test_cli.py
@@ -1,5 +1,6 @@
 """Command-line interface tests."""
 
+import json
 import os
 import sys
 from unittest.mock import patch
@@ -27,6 +28,9 @@ def test_ds005115_deriv_only(data_dir, output_dir, working_dir):
     fmriprep_dir = download_test_data('ds005115_deriv_mni6', data_dir)
     out_dir = os.path.join(output_dir, test_name)
 
+    with open(os.path.join(out_dir, 'filter.json'), 'w') as f:
+        json.dump({'task': ['mixedgamblestask']}, f)
+
     parameters = [
         fmriprep_dir,
         out_dir,
@@ -37,6 +41,8 @@ def test_ds005115_deriv_only(data_dir, output_dir, working_dir):
         'aggr',
         'nonaggr',
         'orthaggr',
+        '--bids-filter-file',
+        os.path.join(out_dir, 'filter.json'),
     ]
     _run_and_generate(
         test_name=test_name,

--- a/src/fmripost_aroma/workflows/base.py
+++ b/src/fmripost_aroma/workflows/base.py
@@ -302,7 +302,8 @@ def init_single_run_wf(bold_file):
     bold_metadata = config.execution.layout.get_metadata(bold_file)
     mem_gb = estimate_bold_mem_usage(bold_file)[1]
 
-    entities = extract_entities(bold_file)
+    entities = config.execution.bids_filters or {}
+    entities = {**entities, **extract_entities(bold_file)}
 
     functional_cache = defaultdict(list, {})
     if config.execution.derivatives:


### PR DESCRIPTION
Closes #108.

## Changes proposed in this pull request

<!--
Please describe here the main features / changes proposed for review and integration in fMRIPost-AROMA
If this PR addresses some existing problem, please use GitHub's citing tools
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *fMRIPost-AROMA* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->


## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->



<!--
Welcome, new contributors!

We ask you to read through the Contributing Guide:
https://github.com/nipreps/fmripost-aroma/blob/master/CONTRIBUTING.md

These are guidelines intended to make communication easier by describing a consistent process, but
don't worry if you don't get it everything exactly "right" on the first try.

To boil it down, here are some highlights:

1) Consider starting a conversation in the issues list before submitting a pull request. The discussion might save you a
   lot of time coding.
2) Please use descriptive prefixes in your pull request title, such as "ENH:" for an enhancement or "FIX:" for a bug fix.
   (See the Contributing guide for the full set.) And consider adding a "WIP" tag for works-in-progress.
3) Any code you submit will be licensed under the same terms (Apache License 2.0) as the rest of fMRIPost-AROMA.
4) We invite every contributor to add themselves to the `.zenodo.json` file
   (https://github.com/nipreps/fmripost-aroma/blob/master/.zenodo.json), which will result in your being listed as an author
   at the next release. Please add yourself as the next-to-last entry, just above Russ.

A pull request is a conversation. We may ask you to make some changes before accepting your PR,
and likewise, you should feel free to ask us any questions you have.

-->
