### PR TITLE
Set zooms of non-aggressively denoised image

### DIFF
--- a/src/fmripost_aroma/interfaces/confounds.py
+++ b/src/fmripost_aroma/interfaces/confounds.py
@@ -155,6 +155,7 @@ class ICADenoise(SimpleInterface):
     output_spec = _ICADenoiseOutputSpec
 
     def _run_interface(self, runtime):
+        import nibabel as nb
         import numpy as np
         import pandas as pd
         from nilearn.maskers import NiftiMasker
@@ -225,7 +226,8 @@ class ICADenoise(SimpleInterface):
         else:
             # Non-aggressive denoising
             # Apply the mask to the data image to get a 2d array
-            data = apply_mask(bold_file, self.inputs.mask_file)
+            bold_img = nb.load(bold_file)
+            data = apply_mask(bold_img, self.inputs.mask_file)
 
             # Fit GLM to accepted components and rejected components (after adding a constant term)
             regressors = np.hstack(
@@ -244,6 +246,7 @@ class ICADenoise(SimpleInterface):
 
             # Save to file
             denoised_img = unmask(data_denoised, self.inputs.mask_file)
+            denoised_img.header.set_zooms(bold_img.header.get_zooms())
 
         self._results['denoised_file'] = os.path.abspath('denoised.nii.gz')
         denoised_img.to_filename(self._results['denoised_file'])

--- a/src/fmripost_aroma/interfaces/confounds.py
+++ b/src/fmripost_aroma/interfaces/confounds.py
@@ -247,6 +247,7 @@ class ICADenoise(SimpleInterface):
             # Save to file
             denoised_img = unmask(data_denoised, self.inputs.mask_file)
             denoised_img.header.set_zooms(bold_img.header.get_zooms())
+            denoised_img.header.set_xyzt_units(*bold_img.header.get_xyzt_units())
 
         self._results['denoised_file'] = os.path.abspath('denoised.nii.gz')
         denoised_img.to_filename(self._results['denoised_file'])


### PR DESCRIPTION
Closes #119.

## Changes proposed in this pull request

- Grab the zooms and associated units from the preprocessed BOLD image to patch into the non-aggressively denoised BOLD image. Non-aggressive denoising is the only one that doesn't rely on nilearn's NiftiMasker, which should set the zooms correctly automatically, so it's the only one that needs a special fix.