### PR TITLE
Add support to control melodic seed

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -28,6 +28,11 @@
       "affiliation": "Charite Universitätsmedizin Berlin, Germany",
       "name": "Waller, Lea",
       "orcid": "0000-0002-3239-6957"
+    },
+    {
+      "affiliation": "University of Amsterdam, The Netherlands",
+      "name": "Céspedes, Violeta",
+      "orcid": "0000-0002-0983-4170"
     }
   ],
   "creators": [

--- a/src/fmripost_aroma/cli/parser.py
+++ b/src/fmripost_aroma/cli/parser.py
@@ -184,7 +184,7 @@ def _build_parser(**kwargs):
         help='Denoising method to apply, if any.',
     )
     g_aroma.add_argument(
-        '--seed',
+        '--melodic-seed',
         dest='melodic_seed',
         action='store',
         type=int,
@@ -192,7 +192,7 @@ def _build_parser(**kwargs):
         help=(
             'Seed for the random number generator used by FSL MELODIC. '
             'Setting this ensures reproducible ICA decomposition. '
-            'If not set, MELODIC uses its own default (non-reproducible) seeding.'
+            'If not set, a time-based seed will be generated for reproducibility.'
         ),
     )
 

--- a/src/fmripost_aroma/cli/parser.py
+++ b/src/fmripost_aroma/cli/parser.py
@@ -185,7 +185,7 @@ def _build_parser(**kwargs):
     )
     g_aroma.add_argument(
         '--seed',
-        dest='melodic',
+        dest='melodic_seed',
         action='store',
         type=int,
         default=None,

--- a/src/fmripost_aroma/cli/parser.py
+++ b/src/fmripost_aroma/cli/parser.py
@@ -183,6 +183,18 @@ def _build_parser(**kwargs):
         dest='denoise_method',
         help='Denoising method to apply, if any.',
     )
+    g_aroma.add_argument(
+        '--seed',
+        dest='melodic',
+        action='store',
+        type=int,
+        default=None,
+        help=(
+            'Seed for the random number generator used by FSL MELODIC. '
+            'Setting this ensures reproducible ICA decomposition. '
+            'If not set, MELODIC uses its own default (non-reproducible) seeding.'
+        ),
+    )
 
     g_bids = parser.add_argument_group('Options for filtering BIDS queries')
     g_bids.add_argument(

--- a/src/fmripost_aroma/config.py
+++ b/src/fmripost_aroma/config.py
@@ -612,7 +612,7 @@ class seeds(_Config):
     numpy = None
     """Seed used by NumPy"""
     melodic_seed = None
-    """Seed for FSL MELODIC ICA. If None, MELODIC uses its own default (non-reproducible)."""
+    """Seed for FSL MELODIC ICA."""
 
     @classmethod
     def init(cls):
@@ -624,7 +624,7 @@ class seeds(_Config):
         # functions to set program specific seeds
         cls.ants = _set_ants_seed()
         cls.numpy = _set_numpy_seed()
-        # melodic_seed is only set if explicitly provided via --seed CLI argument
+        cls.melodic_seed = _set_melodic_seed()
 
 
 def _set_ants_seed():
@@ -641,6 +641,18 @@ def _set_numpy_seed():
     val = random.randint(1, 65536)
     np.random.seed(val)
     return val
+
+
+def _set_melodic_seed():
+    """Set seed for FSL MELODIC ICA decomposition.
+    If the user provided a seed via --melodic-seed, use that value.
+    Otherwise, generate a time-based seed to mimic FSL's default seeding behavior
+    """
+    if seeds.melodic_seed is not None:
+        return seeds.melodic_seed
+    import time
+
+    return int(time.time())
 
 
 def from_dict(settings, init=True, ignore=None):

--- a/src/fmripost_aroma/config.py
+++ b/src/fmripost_aroma/config.py
@@ -611,6 +611,8 @@ class seeds(_Config):
     """Seed used for antsRegistration, antsAI, antsMotionCorr"""
     numpy = None
     """Seed used by NumPy"""
+    melodic = None
+    """Seed for FSL MELODIC ICA. If None, MELODIC uses its own default (non-reproducible)."""
 
     @classmethod
     def init(cls):
@@ -622,6 +624,7 @@ class seeds(_Config):
         # functions to set program specific seeds
         cls.ants = _set_ants_seed()
         cls.numpy = _set_numpy_seed()
+        # melodic seed is only set if explicitly provided via --seed CLI argument
 
 
 def _set_ants_seed():

--- a/src/fmripost_aroma/config.py
+++ b/src/fmripost_aroma/config.py
@@ -611,7 +611,7 @@ class seeds(_Config):
     """Seed used for antsRegistration, antsAI, antsMotionCorr"""
     numpy = None
     """Seed used by NumPy"""
-    melodic = None
+    melodic_seed = None
     """Seed for FSL MELODIC ICA. If None, MELODIC uses its own default (non-reproducible)."""
 
     @classmethod
@@ -624,7 +624,7 @@ class seeds(_Config):
         # functions to set program specific seeds
         cls.ants = _set_ants_seed()
         cls.numpy = _set_numpy_seed()
-        # melodic seed is only set if explicitly provided via --seed CLI argument
+        # melodic_seed is only set if explicitly provided via --seed CLI argument
 
 
 def _set_ants_seed():

--- a/src/fmripost_aroma/tests/test_base.py
+++ b/src/fmripost_aroma/tests/test_base.py
@@ -4,6 +4,7 @@ from fmriprep.workflows.tests import mock_config
 
 from fmripost_aroma import config
 
+
 def test_init_ica_aroma_wf(tmp_path_factory):
     from fmripost_aroma.workflows.aroma import init_ica_aroma_wf
 
@@ -15,7 +16,7 @@ def test_init_ica_aroma_wf(tmp_path_factory):
         config.workflow.denoise_method = ['nonaggr', 'orthaggr']
         config.workflow.melodic_dim = -200
         config.workflow.err_on_warn = False
-        config.seeds.melodic_seed = 12345
+        config.seeds.init()
 
         wf = init_ica_aroma_wf(
             bold_file='sub-01_task-rest_bold.nii.gz',
@@ -24,7 +25,9 @@ def test_init_ica_aroma_wf(tmp_path_factory):
         )
         assert wf.name == 'aroma_task_rest_wf'
         melodic_node = wf.get_node('melodic')
-        assert '--seed=12345' in melodic_node.inputs.args
+        assert melodic_node.inputs.args.startswith('--seed=')
+        seed_value = melodic_node.inputs.args.split('=')[1]
+        assert seed_value.isdigit(), f'Expected integer seed, got: {seed_value}'
 
 
 def test_init_denoise_wf(tmp_path_factory):

--- a/src/fmripost_aroma/tests/test_base.py
+++ b/src/fmripost_aroma/tests/test_base.py
@@ -4,7 +4,6 @@ from fmriprep.workflows.tests import mock_config
 
 from fmripost_aroma import config
 
-
 def test_init_ica_aroma_wf(tmp_path_factory):
     from fmripost_aroma.workflows.aroma import init_ica_aroma_wf
 
@@ -16,6 +15,7 @@ def test_init_ica_aroma_wf(tmp_path_factory):
         config.workflow.denoise_method = ['nonaggr', 'orthaggr']
         config.workflow.melodic_dim = -200
         config.workflow.err_on_warn = False
+        config.seeds.melodic = 12345
 
         wf = init_ica_aroma_wf(
             bold_file='sub-01_task-rest_bold.nii.gz',
@@ -23,6 +23,8 @@ def test_init_ica_aroma_wf(tmp_path_factory):
             mem_gb={'resampled': 1},
         )
         assert wf.name == 'aroma_task_rest_wf'
+        melodic_node = wf.get_node('melodic')
+        assert '--seed=12345' in melodic_node.inputs.args
 
 
 def test_init_denoise_wf(tmp_path_factory):

--- a/src/fmripost_aroma/tests/test_base.py
+++ b/src/fmripost_aroma/tests/test_base.py
@@ -15,7 +15,7 @@ def test_init_ica_aroma_wf(tmp_path_factory):
         config.workflow.denoise_method = ['nonaggr', 'orthaggr']
         config.workflow.melodic_dim = -200
         config.workflow.err_on_warn = False
-        config.seeds.melodic = 12345
+        config.seeds.melodic_seed = 12345
 
         wf = init_ica_aroma_wf(
             bold_file='sub-01_task-rest_bold.nii.gz',

--- a/src/fmripost_aroma/workflows/aroma.py
+++ b/src/fmripost_aroma/workflows/aroma.py
@@ -212,7 +212,7 @@ in the corresponding confounds file.
             mm_thresh=0.5,
             out_stats=True,
             dim=config.workflow.melodic_dim,
-            args=f'--seed={config.seeds.melodic}' if config.seeds.melodic is not None else '',
+            args=f'--seed={config.seeds.melodic_seed}' if config.seeds.melodic_seed is not None else '',
         ),
         name='melodic',
         mem_gb=mem_gb['resampled'],

--- a/src/fmripost_aroma/workflows/aroma.py
+++ b/src/fmripost_aroma/workflows/aroma.py
@@ -212,7 +212,7 @@ in the corresponding confounds file.
             mm_thresh=0.5,
             out_stats=True,
             dim=config.workflow.melodic_dim,
-            args=f'--seed={config.seeds.melodic_seed}' if config.seeds.melodic_seed is not None else '',
+            args=f'--seed={config.seeds.melodic_seed}',
         ),
         name='melodic',
         mem_gb=mem_gb['resampled'],

--- a/src/fmripost_aroma/workflows/aroma.py
+++ b/src/fmripost_aroma/workflows/aroma.py
@@ -212,6 +212,7 @@ in the corresponding confounds file.
             mm_thresh=0.5,
             out_stats=True,
             dim=config.workflow.melodic_dim,
+            args=f'--seed={config.seeds.melodic}' if config.seeds.melodic is not None else '',
         ),
         name='melodic',
         mem_gb=mem_gb['resampled'],


### PR DESCRIPTION
Hello! Vi here. 
At HALFpipe we are doing some investigation into ICA-AROMA and we would like to have the capacity to set the seed. This PR adds a --melodic_seed command-line argument to control the random number generator seed used by FSL MELODIC during ICA decomposition. This enables reproducible ICA results across runs. 

The [option](https://git.fmrib.ox.ac.uk/fsl/melodic/-/blob/master/meloptions.h) already exists in the source code, but the  nipype's fsl.MELODIC interface doesn't expose every MELODIC option as a direct Python parameter. The args parameter (inherited from [CommandLineInputSpec](https://github.com/nipy/nipype/blob/8234ec318489930fa17487cf15d210420214b00a/nipype/interfaces/base/specs.py#L402 )) allows passing arbitrary additional command-line arguments. 

## Changes proposed in this pull request

- Add --melodic_seed CLI argument in parser.py 
- Add seeds.melodic_seed attribute in config.py
- Pass seed to MELODIC via args parameter in aroma.py workflow
- Update test to verify seed is correctly passed to MELODIC node (I can make it into its own unit test if you prefer this of course!)

When --melodic_seed is not provided, MELODIC uses its own default seeding behavior (which is non-reproducible).

Another option would be patching Nipype FSL interface upstream, but I thought this might be faster. 
Let me know what you think!

